### PR TITLE
Perbaiki error saat nama kota/kabupaten tidak di temukan

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,10 +1,11 @@
 preset: laravel
+
 enabled:
-  - alpha_ordered_imports
+- length_ordered_imports
+- long_list_syntax
+
 disabled:
-  - length_ordered_imports
-  - unused_use
-finder:
-  not-name:
-    - index.php
-    - server.php
+- self_accessor
+- short_list_syntax
+- alpha_ordered_imports
+- single_class_element_per_statement

--- a/src/SearchDrivers/BasicDriver.php
+++ b/src/SearchDrivers/BasicDriver.php
@@ -10,9 +10,12 @@ class BasicDriver extends AbstractDriver
      */
     public function search(string $searchQuery): array
     {
+        $result = [];
+        $q = trim(strtolower($searchQuery));
         $rowColumn = array_column($this->collection, $this->searchColumn);
-        $s = preg_replace('/(\s|$)/', '.+?$1', preg_quote($searchQuery, '/'));
-        $res = preg_grep('/^'.$s.'/i', $rowColumn);
+        $data = array_map('strtolower', $rowColumn);
+        $cari = preg_quote($q, '/');
+        $res = preg_grep('/'.$cari.'/', $data);
         $resKey = array_keys($res);
         foreach ($this->collection as $key => $val) {
             if (in_array($key, $resKey)) {


### PR DESCRIPTION
Ada error mas kalau keyword tidak ada yang cocok,
Kemudian sedikit perbaikan agar bisa mencari di semua suku kata pada nama kota/kab...
Misalnya ingin mencari kab "batang hari" dengan keyword : 
`$ResultKota = RajaOngkir::kota()->search('ng har')->get();`
        // atau
`$ResultKota = RajaOngkir::kota()->search('ata')->get();`
       // atau
`$ResultKota = RajaOngkir::kota()->search('ari')->get();`
       // atau
`$ResultKota = RajaOngkir::kota()->search('Ari')->get();`